### PR TITLE
updateVariant() - Remove async callback to follow pattern of other updates

### DIFF
--- a/server/methods/products/methods.coffee
+++ b/server/methods/products/methods.coffee
@@ -70,10 +70,7 @@ Meteor.methods
       for variants,value in product.variants
         if variants._id is variant._id
           newVariant = _.extend variants,variant
-      Products.update({"_id":product._id,"variants._id":variant._id}, {$set: {"variants.$": newVariant}}, {validate: false}, (error,result) ->
-        console.log error if error
-        return
-      )
+      Products.update({"_id":product._id,"variants._id":variant._id}, {$set: {"variants.$": newVariant}}, {validate: false})
 
   ###
   # update whole variants array
@@ -82,9 +79,7 @@ Meteor.methods
     unless Roles.userIsInRole Meteor.userId(), ['admin']
       throw new Meteor.Error 403, "Access Denied"
     product = Products.findOne "variants._id":variants[0]._id
-    Products.update product._id, $set: variants: variants, {validate: false}, (error,results) ->
-      console.log error if error
-      return
+    Products.update product._id, $set: variants: variants, {validate: false}
 
   ###
   # clone a whole product, defaulting visibility, etc


### PR DESCRIPTION
In ```childVariants.coffee```, a callback is passed to ```Meteor.call('updateVariant', function(error, result) {...```, but the callback will be returned as ```undefined``` right away on ```collection.update(...``` before the update occurs since there is a callback in the ```Products.update(...``` (as per the meteor docs).

Moral of the story is that a callback can only be in the ```collection.update``` stub method call or in the ```Meteor.call```, but not both like for a ```collection.insert```

My other solution for this would be to create an object that stores the ```(error, result)``` values, console.error the error if there is one, then after it is updated, return those values so they are accessible by the ```Meteor.call``` async callback 