### PR TITLE
bug fix - default newVariant needs createdAt/updatedAt

### DIFF
--- a/common/hooks/hooks.coffee
+++ b/common/hooks/hooks.coffee
@@ -50,3 +50,7 @@ Products.before.update (userId, product, fieldNames, modifier, options) ->
         addToSet.updatedAt = updatedAt
   if modifier.$set then modifier.$set.updatedAt = new Date()
   # if modifier.$addToSet then modifier.$addToSet.updatedAt = new Date()
+
+  if modifier.$addToSet?.variants
+    modifier.$addToSet.variants.createdAt = new Date()  unless modifier.$addToSet.variants.createdAt
+    modifier.$addToSet.variants.updatedAt = new Date()  unless modifier.$addToSet.variants.updatedAt


### PR DESCRIPTION
Found this bug when programmatically calling ```createVariant``` meteor method. hooks.js:52 looks like it has the beginnings of $addToSet, but I'm not sure how to implement it to applyDefaults on createVariants (which calls ```Product.update(...{$addToSet...```

I coded it into createVariant because I saw elsewhere in methods.coffee do the same with just updatedAt.

Feel free to reject, but not having createdAt/updatedAt was throwing an error elsewhere in my code :) Thanks!