### PR TITLE
Payment schema update

### DIFF
--- a/common/schemas/orders.coffee
+++ b/common/schemas/orders.coffee
@@ -14,8 +14,10 @@ ReactionCore.Schemas.PaymentMethod = new SimpleSchema
     type: String
   status:
     type: String
+    allowedValues: ["created", "approved", "failed", "canceled", "expired", "pending", "voided", "settled"]
   mode:
     type: String
+    allowedValues: ["sale", "authorization", "order"]
   createdAt:
     type: Date
     optional: true
@@ -28,6 +30,10 @@ ReactionCore.Schemas.PaymentMethod = new SimpleSchema
   amount:
     type: Number
     decimal: true
+  transactions:
+    type: [Object]
+    optional: true
+    blackbox: true
 
 ReactionCore.Schemas.Payment = new SimpleSchema
   address:

--- a/common/schemas/orders.coffee
+++ b/common/schemas/orders.coffee
@@ -17,7 +17,7 @@ ReactionCore.Schemas.PaymentMethod = new SimpleSchema
     allowedValues: ["created", "approved", "failed", "canceled", "expired", "pending", "voided", "settled"]
   mode:
     type: String
-    allowedValues: ["sale", "authorization", "order"]
+    allowedValues: ["authorize", 'capture','refund','void']
   createdAt:
     type: Date
     optional: true


### PR DESCRIPTION
add enforcement for payment schema mode and status
```
  status:
    allowedValues: ["created", "approved", "failed", "canceled", "expired", "pending", "voided", "settled"]
  mode:
    allowedValues: ["authorize", 'capture','refund','void']
```

Successful orders are where paymentMethod.mode is 'authorize' and paymentMethod.status is 'approved'

add `transaction` blackbox object, to store payment providers response object.