### PR TITLE
Social sharing for products

### DIFF
--- a/client/templates/dashboard/orders/social/orderSocial.html
+++ b/client/templates/dashboard/orders/social/orderSocial.html
@@ -18,9 +18,9 @@
             <i class="fa fa-pinterest fa-lg"></i>
           </a>
         </span>
-        <span class="instagram-msg">
-          <a href="#" class="instagram-msg-edit editable-click editable-empty" rel='tooltip' data-value="{{instagramMsg}}" tabindex="-1">
-            <i class="fa fa-instagram fa-lg"></i>
+        <span class="googleplus-msg">
+          <a href="#" class="googleplus-msg-edit editable-click editable-empty" rel='tooltip' data-value="{{googleplusMsg}}" tabindex="-1">
+            <i class="fa fa-google-plus fa-lg"></i>
           </a>
         </span>
         {{!--  orderProfile Email --}}
@@ -37,7 +37,8 @@
         <a href="#"><i class="fa fa-facebook fa-lg"></i></a>
         <a href="#"><i class="fa fa-twitter fa-lg"></i></a>
         <a href="#"><i class="fa fa-pinterest fa-lg"> </i></a>
-        <a href="#"><i class="fa fa-instagram fa-lg"></i></a>
+        <a href="#"><i class="fa fa-google-plus fa-lg"></i></a>
+        {{>shareit}}
     {{/if}}
   </div>
 </template>

--- a/client/templates/dashboard/settings/settingsGeneral/settingsGeneral.coffee
+++ b/client/templates/dashboard/settings/settingsGeneral/settingsGeneral.coffee
@@ -35,6 +35,16 @@ Template.settingsGeneral.helpers
     for measure, uom of unitsOfMeasure
       uomOptions.push {label: uom.name, value: measure}
     return uomOptions
+  
+  socialOptions: ->
+    socials = ReactionCore.Collections.Shops.findOne().socials
+    #socialOptions = []
+    #for social, values of socials
+    #  console.log(social)
+    #  console.log(values.appId)
+    #  socialOptions.push {label: social, value: values.appId}
+    #return socialOptions
+    return socials
 
   portOptions: [
     {label: 25, value: 25}

--- a/client/templates/dashboard/settings/settingsGeneral/settingsGeneral.coffee
+++ b/client/templates/dashboard/settings/settingsGeneral/settingsGeneral.coffee
@@ -38,12 +38,6 @@ Template.settingsGeneral.helpers
   
   socialOptions: ->
     socials = ReactionCore.Collections.Shops.findOne().socials
-    #socialOptions = []
-    #for social, values of socials
-    #  console.log(social)
-    #  console.log(values.appId)
-    #  socialOptions.push {label: social, value: values.appId}
-    #return socialOptions
     return socials
 
   portOptions: [

--- a/client/templates/dashboard/settings/settingsGeneral/settingsGeneral.html
+++ b/client/templates/dashboard/settings/settingsGeneral/settingsGeneral.html
@@ -1,11 +1,12 @@
 <template name="settingsGeneral">
 <h2>Shop <small data-18n="app.settings">Settings</small></h2>
-<div class="col-md-5">
+<div class="col-md-6">
 <ul class="nav nav-tabs">
   <li class="active"><a href="#general" data-toggle="tab">General</a></li>
   <li><a href="#address" data-toggle="tab">Address</a></li>
   <li><a href="#smtp" data-toggle="tab">SMTP</a></li>
   <li><a href="#settings" data-toggle="tab">Settings</a></li>
+  <li><a href="#social-app-config" data-toggle="tab">Social Apps Configuration</a></li>
 </ul>
 
 <!-- Tab panes -->
@@ -54,6 +55,14 @@
         {{> afQuickField name='timezone' options=timezoneOptions}}
         {{> afQuickField name='currency' options=currencyOptions}}
         {{> afQuickField name='baseUOM' options=uomOptions}}
+        {{> settingsGeneralSubmitButton}}
+      {{/autoForm}}
+    </div>
+  </div>
+  <div class="tab-pane" id="social-app-config">
+    <div class="well">
+      {{#autoForm collection="Shops" doc=. id="shopEditSocialForm" type="update"}}
+        {{> afQuickField name='socials.facebook.appId'}}
         {{> settingsGeneralSubmitButton}}
       {{/autoForm}}
     </div>

--- a/client/templates/products/productDetail/productDetail.coffee
+++ b/client/templates/products/productDetail/productDetail.coffee
@@ -34,8 +34,7 @@ Template.productDetail.helpers
       return Template.productMetaFieldForm
     else
       return Template.productMetaField
-
-
+  
 Template.productDetail.events
   "click #price": ->
     # When an admin clicks on the main price to edit it, instead
@@ -163,11 +162,14 @@ Template.productDetail.events
       $(".pinterestMsg-edit").fadeIn()
       $(".pinterestMsg-edit-input").focus()
 
-  "click .fa-instagram": ->
+  "click .fa-google-plus": ->
     if ReactionCore.hasOwnerAccess()
-      $(".instagramMsg-edit").fadeIn()
-      $(".instagramMsg-edit-input").focus()
+      $(".googleplusMsg-edit").fadeIn()
+      $(".googleplusMsg-edit-input").focus()
 
-  "focusout .facebookMsg-edit-input,.twitterMsg-edit-input,.pinterestMsg-edit-input": ->
+  "focusout .facebookMsg-edit-input,.twitterMsg-edit-input,.pinterestMsg-edit-input,.googleplusMsg-edit-input": ->
     Session.set "editing-"+this.field, false
     $('.social-media-inputs > *').hide()
+    
+Template.productDetail.rendered = ->
+  Session.set('socialImgSrc', $('.img-responsive').attr('src'))

--- a/client/templates/products/productDetail/productDetail.html
+++ b/client/templates/products/productDetail/productDetail.html
@@ -59,12 +59,12 @@
               <a href="#"><i class="fa fa-facebook fa-lg"></i></a>
               <a href="#"><i class="fa fa-twitter fa-lg"></i></a>
               <a href="#"><i class="fa fa-pinterest fa-lg"> </i></a>
-              <a href="#"><i class="fa fa-instagram fa-lg"></i></a>
+              <a href="#"><i class="fa fa-google-plus fa-lg"></i></a>
               <div class="social-media-inputs">
                 {{>fieldComponent field="facebookMsg" value=facebookMsg}}
                 {{>fieldComponent field="twitterMsg" value=twitterMsg}}
                 {{>fieldComponent field="pinterestMsg" value=pinterestMsg}}
-                {{>fieldComponent field="instagramMsg" value=instagramMsg}}
+                {{>fieldComponent field="googleplusMsg" value=googleplusMsg}}
               </div>
             </div>
             {{else}}

--- a/client/templates/products/productDetail/productDetail.import.less
+++ b/client/templates/products/productDetail/productDetail.import.less
@@ -1,0 +1,154 @@
+.pdp-container {
+  input:focus::-webkit-input-placeholder { color:transparent; }
+  input:focus:-moz-placeholder { color:transparent; } /* FF 4-18 */
+  input:focus::-moz-placeholder { color:transparent; } /* FF 19+ */
+
+  .img-responsive {width: 100%;} // For Firefox: http://stackoverflow.com/questions/18846744/responsive-images-in-tables-bootstrap-3
+  width:100%;
+  //== minor layout adjustment for columns
+  .pdp-left-column { padding-right: 15px; }
+  .pdp-right-column { padding-left: 15px; }
+  .product-details { padding-top: 25px; }
+
+  //== product detail fields
+  .price {
+    font-weight: bold;
+    font-size: @product-price-font-size;
+    overflow: visible;
+    display:inline-block;
+    }
+  .currency-symbol {
+    font-weight: bold;
+    font-size: @product-price-font-size;
+    margin-right: -10px;
+  }
+  .social-pricing { margin-left: -10px; }
+  .vendor { margin-top: -5px; }
+
+  //== description and textarea
+  .description {
+    padding-top: 15px;
+    font-weight: 300;
+    font-size: @product-description-font-size;
+    line-height: floor((@font-size-base * @line-height-base) * 1.2); // ~20px
+  }
+
+  .description-edit {
+    .description;
+  }
+  //== main product page title
+  .title  {
+    h1{
+      text-align: center;
+      font-family: @headings-font-family-h1;
+      font-size: @product-title-font-size;
+      font-weight: @headings-font-weight-h1;
+      color: @headings-color-h1;
+    }
+  }
+
+  .title-edit {
+    .title();
+    input {
+        width: 100%;
+        overflow: visible;
+    }
+  }
+  //== page sub title
+  .pageTitle {
+    margin-top: -10px;
+    margin-bottom: 20px;
+    h2{
+      text-align: center;
+      font-family: @headings-font-family-h2;
+      font-size: @product-page-title-font-size;
+      font-weight: @headings-font-weight-h2;
+      color: @headings-color-h2;
+    }
+  }
+
+  .pageTitle-edit {
+    .pageTitle();
+    input {
+        width: 100%;
+        overflow: visible;
+    }
+  }
+
+  .social-media {
+    line-height: 50px;
+    input { width: 100%; }
+  }
+
+  .facebookMsg-edit, .twitterMsg-edit, .pinterestMsg-edit, .instagramMsg-edit, .googleplusMsg-edit {display:none;}
+
+  //== Add to cart block
+  .add-to-cart-block {
+      width: 100%;
+      height: 45px;
+  }
+
+  .add-to-cart-text {
+    font-size: 20px;
+    margin-right: 30px;
+  }
+
+  #add-to-cart-quantity {
+    text-align: center;
+    background-color: aliceblue;
+    height: 32px;
+    width: 54px !important;
+  }
+
+  .options-add-to-cart {
+    fieldset.addToCartQty {
+      position:relative;
+      top:12px;
+    }
+  }
+}
+
+//== default styling for input mode
+.product-detail-edit {
+  position: relative;
+  input {
+    border: 1px solid @body-bg;
+    border-radius: @input-border-focus;
+    text-align: inherit;
+  }
+  input:hover {
+    border: 1px dotted @input-border;
+    border-radius: @input-border-focus;
+    background: @input-bg;
+  }
+  textarea {
+    overflow: auto;
+    border: 1px dotted @body-bg;
+    border-radius: @input-border-focus;
+    // min-height: 100px !important;
+    width: 100%;
+    textarea.vert { resize:vertical; }
+  }
+  textarea:hover {
+    border: 1px dotted @input-border;
+    border-radius: @input-border-focus;
+  }
+
+  .product-detail-message {
+    position: absolute;
+    top: 0;
+    right: 0;
+  }
+}
+
+
+
+
+@media only screen and (max-width: @screen-xs-max) {
+    .pdp-title, .pdp-title h1{
+      font-size: 30px;
+    }
+    .pdp-page-title, .pdp-page-title h2{
+      font-size: 20px;
+    }
+}

--- a/client/templates/products/productDetail/social/social.coffee
+++ b/client/templates/products/productDetail/social/social.coffee
@@ -15,8 +15,7 @@ Template.productSocial.created = ->
     faSize: 'fa-lg'
     classes: ''
     
-  unless FB?
-    FB.init(ShareIt.settings.sites.facebook)  
+  FB.init(ShareIt.settings.sites.facebook)  
   return
   
 Template.productSocial.helpers

--- a/client/templates/products/productDetail/social/social.coffee
+++ b/client/templates/products/productDetail/social/social.coffee
@@ -1,0 +1,41 @@
+Template.productSocial.created = ->
+  socials = ReactionCore.Collections.Shops.findOne(ReactionCore.shopId).socials
+    
+  ShareIt.configure
+    autoInit: false
+    sites: 
+      'facebook':
+        'xbfml': false
+        'appId': socials.facebook.appId
+      'twitter': {}
+      'pinterest': {}
+      'googleplus': {}
+    iconOnly: true
+    applyColors: false
+    faSize: 'fa-lg'
+    classes: ''
+    
+  unless FB?
+    FB.init(ShareIt.settings.sites.facebook)  
+  return
+  
+Template.productSocial.helpers
+  socialData: () ->
+    product = selectedProduct()
+    current = selectedVariant()
+    imgSrc = Session.get('socialImgSrc')
+    
+    url: window.location.href
+    title: current.title
+    description: product.description.substring(0, 254)
+    facebook:
+      description: product.facebookMsg
+    twitter:
+      title: product.twitterMsg
+    pinterest:
+      description: product.pinterestMsg
+    googleplus:
+      itemtype: 'Product'
+      description: product.googleplusMsg
+    media: imgSrc
+    thumbnail: imgSrc

--- a/client/templates/products/productDetail/social/social.html
+++ b/client/templates/products/productDetail/social/social.html
@@ -1,9 +1,6 @@
 <template name="productSocial">
 <div class="social-media">
   {{!-- Social Commentary --}}
-  <a href="#"><i class="fa fa-facebook fa-lg"></i></a>
-  <a href="#"><i class="fa fa-twitter fa-lg"></i></a>
-  <a href="#"><i class="fa fa-pinterest fa-lg"> </i></a>
-  <a href="#"><i class="fa fa-instagram fa-lg"></i></a>
+  {{> shareit socialData}}
 </div>
 </template>

--- a/client/templates/products/productDetail/variants/variantList/variantList.coffee
+++ b/client/templates/products/productDetail/variants/variantList/variantList.coffee
@@ -38,3 +38,4 @@ Template.variantList.events
     $(event.target).addClass("active")
     Alerts.removeSeen()
     setCurrentVariant @._id
+    Session.set('socialImgSrc', $('.img-responsive').attr('src'))

--- a/common/schemas/products.coffee
+++ b/common/schemas/products.coffee
@@ -171,7 +171,7 @@ ReactionCore.Schemas.Product = new SimpleSchema
     type: String
     optional: true
     max: 255
-  instagramMsg:
+  googleplusMsg:
     type: String
     optional: true
     max: 255

--- a/common/schemas/shops.coffee
+++ b/common/schemas/shops.coffee
@@ -129,6 +129,15 @@ ReactionCore.Schemas.currencyEngine = new SimpleSchema
     optional: true
     label: "Open Exchange Rates App ID"
 
+ReactionCore.Schemas.Socials = new SimpleSchema
+  facebook:
+    type: Object
+    optional: true
+  'facebook.appId':
+    type: String
+    optional: true
+    label: 'Facebook App Id'
+
 ReactionCore.Schemas.Shop = new SimpleSchema
   _id:
     type: String
@@ -156,6 +165,10 @@ ReactionCore.Schemas.Shop = new SimpleSchema
     type: ReactionCore.Schemas.currencyEngine
   currencies:
     type: [ReactionCore.Schemas.Currency]
+  socials:
+    type: ReactionCore.Schemas.Socials
+    optional: true
+    label: "Social Apps Configuration"
   public:
     type: String
     optional: true

--- a/docs/analyticsEvents.md
+++ b/docs/analyticsEvents.md
@@ -296,7 +296,7 @@ A user clicks on the Instagram icon footer link.
     "category" : "link",
     "action" : "link-click",
     "label" : "external link click",
-    "value" : "instagram",
+    "value" : "googleplus",
     "shopId" : "WvrKDomkYth3THbDD",
     "_id" : "zhPxLcBehiJEFd2JA"
 }

--- a/package.js
+++ b/package.js
@@ -70,6 +70,7 @@ Package.onUse(function (api) {
     api.use("cfs:s3@0.1.1");
     api.use("cfs:ui@0.1.3");
     api.use("raix:ui-dropped-event@0.0.7");
+    api.use("lovetostrike:shareit", 'client');
 
     //implying these are reused in reaction packages
     api.imply("less");
@@ -93,7 +94,6 @@ Package.onUse(function (api) {
     api.imply("sacha:spin" ["client"]);
     api.imply("dburles:factory");
     api.imply("ongoworks:speakingurl");
-
 
   // Pre-0.9.0
   } else {

--- a/private/data/Shops.json
+++ b/private/data/Shops.json
@@ -374,6 +374,11 @@
             "provider": "OXR",
             "apiKey": ""
         },
+        "socials": {
+          "facebook": {
+               "appId": ""
+          }                    
+        },
         "customEmailSettings": {
             "port": 25
         },

--- a/server/factories.coffee
+++ b/server/factories.coffee
@@ -21,6 +21,9 @@ Factory.define 'shop', ReactionCore.Collections.Shops,
   currency: "USD"
   currencyEngine: undefined
   currencies: []
+  socials:
+    facebook:
+      appId: ''
   public: true
   timezone: '1'
   baseUOM: "OZ"
@@ -64,7 +67,7 @@ Factory.define 'product', ReactionCore.Collections.Products,
   hashtags: []
 #   twitterMsg:
 #   facebookMsg:
-#   instagramMsg:
+#   googleplusMsg:
 #   pinterestMsg:
 #   metaDescription:
 #   handle:

--- a/server/fixtures.coffee
+++ b/server/fixtures.coffee
@@ -104,12 +104,20 @@ loadFixtures = ->
 
   # Load data from settings/json files
   unless Accounts.loginServiceConfiguration.find().count()
-    if Meteor.settings.public?.facebook?.appId
+    if Meteor.settings.socials?.public?.facebook?.appId
       Accounts.loginServiceConfiguration.insert
         service: "facebook",
-        appId: Meteor.settings.public.facebook.appId,
-        secret: Meteor.settings.facebook.secret
-
+        appId: Meteor.settings.socials.public.facebook.appId,
+        secret: Meteor.settings.socials.private.facebook.secret
+        
+  # load social app config from settings/json files
+  if Meteor.settings.socials?.public?
+    if Meteor.settings.socials.public.facebook?.appId?
+      shopId = Shops.findOne()._id
+      Shops.update shopId,
+        $set:
+          'socials.facebook.appId': Meteor.settings.socials.public.facebook.appId
+        
   # Loop through ReactionCore.Packages object, which now has all packages added by
   # calls to register
   # removes package when removed from meteor, retriggers when package added


### PR DESCRIPTION
Towards https://github.com/reactioncommerce/reaction/issues/61
Needed by https://github.com/reactioncommerce/reaction-core-theme/pull/8

Added lovetostrike:shareit
Added admin setting interface for social apps
Replaced instagram with googleplus

TODO:
Decide what to show for products without image(default)
Also wire up footer social sharing and create admin settings for that.