### PR TITLE
Fix issue where rearranged products would not be saved on server. 

### DIFF
--- a/common/schemas/products.coffee
+++ b/common/schemas/products.coffee
@@ -32,7 +32,7 @@ ReactionCore.Schemas.ProductPosition = new SimpleSchema
     type: Number
     optional: true
   weight:
-    type: String
+    type: Number
     optional: true
   updatedAt:
     type: Date
@@ -112,9 +112,6 @@ ReactionCore.Schemas.ProductVariant = new SimpleSchema
   metafields:
     type: [ReactionCore.Schemas.Metafield]
     optional: true
-  positions:
-    type: [ReactionCore.Schemas.ProductPosition]
-    optional: true
   createdAt:
     label: "Created at"
     type: Date
@@ -150,6 +147,9 @@ ReactionCore.Schemas.Product = new SimpleSchema
   metafields:
     type: [ReactionCore.Schemas.Metafield]
     optional: true
+  positions:
+    type: [ReactionCore.Schemas.ProductPosition]
+    optional: true    
   variants:
     type: [ReactionCore.Schemas.ProductVariant]
   requiresShipping:


### PR DESCRIPTION
Moves positions object from Variant schema to Product schema. Found this bug while writing tests for product and variant methods. Schema change fixes issue where rearranging products (via drag and drop) would not be saved on the server.