### PR TITLE
Fixes to the #350 issue and further the use of packages for shops

### DIFF
--- a/client/helpers/spacebars.coffee
+++ b/client/helpers/spacebars.coffee
@@ -296,6 +296,7 @@ Template.registerHelper "navLink", (page, icon) ->
 #
 ###
 Template.registerHelper "reactionApps", (options) ->
+  unless options.hash.shopId then options.hash.shopId = ReactionCore.getShopId()
   reactionApps = []
   filter = {}
   registryFilter = {}

--- a/client/helpers/spacebars.coffee
+++ b/client/helpers/spacebars.coffee
@@ -301,7 +301,7 @@ Template.registerHelper "reactionApps", (options) ->
   registryFilter = {}
   # any registry property, name, enabled can be used as filter
   for key, value of options.hash
-    unless key is 'enabled' or key is 'name'
+    unless key is 'enabled' or key is 'name' or key is 'shopId'
       filter['registry.' + key] = value #for query
       registryFilter[key] = value #for registry filter
     else

--- a/server/fixtures.coffee
+++ b/server/fixtures.coffee
@@ -178,12 +178,13 @@ loadFixtures = ->
   # Loop through ReactionRegistry.Packages object, which now has all packages added by
   # calls to register
   # removes package when removed from meteor, retriggers when package added
-  unless ReactionCore.Collections.Packages.find().count() is Object.keys(ReactionRegistry.Packages).length
+  unless ReactionCore.Collections.Packages.find().count() is Shops.find().count() * Object.keys(ReactionRegistry.Packages).length
     _.each ReactionRegistry.Packages, (config, pkgName) ->
       Shops.find().forEach (shop) ->
         ReactionCore.Events.info "Initializing "+ pkgName
         ReactionCore.Collections.Packages.upsert {shopId: shop._id, name: pkgName},
           $setOnInsert:
+            shopId: shop._id
             enabled: !!config.autoEnable
             settings: config.settings
             registry: config.registry


### PR DESCRIPTION
Hi Aaron, 
According to out discussion I created a pull request that fixes 
 - the package multiplication issue reported in #350.
 - It also contains some additional filters like shopId in the reactionApp helper so that we can filter the packages by shops
 - Furthermore it contains a fix for the upsert because the new package insert used the ReactionCore.shopId for every insert instead of the shop.shopId