### PR TITLE
Don't display all related (tagged) products when viewing the product

### DIFF
--- a/client/helpers/helpers.coffee
+++ b/client/helpers/helpers.coffee
@@ -45,8 +45,8 @@ String::toCamelCase = ->
       for relatedTag in relatedTags
         if hashtags.indexOf(relatedTag._id) == -1
           hashtags.push(relatedTag._id)
-          if relatedTag.relatedTagIds?.length
-            newRelatedTags = _.union(newRelatedTags, Tags.find({_id: {$in: relatedTag.relatedTagIds}}).fetch())
+          #if relatedTag.relatedTagIds?.length
+          #  newRelatedTags = _.union(newRelatedTags, Tags.find({_id: {$in: relatedTag.relatedTagIds}}).fetch())
       relatedTags = newRelatedTags
     selector.hashtags = {$in: hashtags}
   cursor = Products.find(selector)

--- a/client/templates/products/productGrid/productGrid.coffee
+++ b/client/templates/products/productGrid/productGrid.coffee
@@ -23,8 +23,8 @@ Template.productGrid.helpers
         for relatedTag in relatedTags
           if hashtags.indexOf(relatedTag._id) == -1
             hashtags.push(relatedTag._id)
-            if relatedTag.relatedTagIds?.length
-              newRelatedTags = _.union(newRelatedTags, Tags.find({_id: {$in: relatedTag.relatedTagIds}}).fetch())
+            #if relatedTag.relatedTagIds?.length
+            #  newRelatedTags = _.union(newRelatedTags, Tags.find({_id: {$in: relatedTag.relatedTagIds}}).fetch())
         relatedTags = newRelatedTags
       selector.hashtags = {$in: hashtags}
     gridProducts = Products.find(selector).fetch()


### PR DESCRIPTION
which holds them.

In my opinion it is wrong to automatically accumulate all related
products and show them all in the product grid. There are use cases where
one don't want to display the related products implicitly in the product
grid but still have related tags where one can navigate into it to get even
more products (e.g. the related products).

If one really wants the related products to appear along with its
parent, one can still tag them with both tags to yield the current
behaviour.