### PR TITLE
Adding the states dropdown to addressBookForm, and changes to hasPermission to support multi vendor sellers

### DIFF
--- a/client/app.coffee
+++ b/client/app.coffee
@@ -26,8 +26,10 @@ _.extend ReactionCore,
       return true
     else if Roles.userIsInRole userId, permissions, Roles.GLOBAL_GROUP
       return true
-    else return false
-
+    for shop in @getSellerShopId()
+      if Roles.userIsInRole userId, permissions, shop
+        return true  
+    return false
 
   hasOwnerAccess: ->
     ownerPermissions = ['owner']
@@ -52,7 +54,7 @@ _.extend ReactionCore,
 
   # return the logged in user's shop[s] if he owns any or if he is an admin -> used in multivendor
   getSellerShopId: (client) ->
-    return Roles.getGroupsForUser Meteor.userId(), ['owner','admin']
+    return Roles.getGroupsForUser Meteor.userId(), 'admin'
 
 Meteor.startup ->
   ###

--- a/client/templates/cart/checkout/addressBook/form/form.coffee
+++ b/client/templates/cart/checkout/addressBook/form/form.coffee
@@ -8,6 +8,17 @@ Template.addressBookForm.helpers
     for country, locale of shop?.locales.countries
       options.push {'label': locale.name, 'value': country}
     return options
+  statesForCountry: ->
+    shop = ReactionCore.Collections.Shops.findOne()
+    selectedCountry = AutoForm.getFieldValue(@._af.formId,"country")
+    unless selectedCountry  
+      return false
+    unless shop?.locales.countries[selectedCountry].states?  
+      return false
+    options = []  
+    for state, locale of shop?.locales.countries[selectedCountry].states
+      options.push {'label': locale.name, 'value': state}
+    return options
 
   #
   # TODO: state/regions dropdown / auto populate

--- a/client/templates/cart/checkout/addressBook/form/form.html
+++ b/client/templates/cart/checkout/addressBook/form/form.html
@@ -50,7 +50,11 @@
   </div>
   <div class="col-md-4 form-group{{#if afFieldIsInvalid name='region'}} has-error{{/if}}">
       <label class="control-label">{{afFieldLabelText name='region'}}</label>
-      {{>afFieldInput name="region" value=region}}
+      {{#if statesForCountry}}
+        {{>afFieldInput name="region" value=region options=statesForCountry}}
+      {{else}}
+        {{>afFieldInput name="region" value=region }}
+      {{/if}}
       {{#if afFieldIsInvalid name="region"}}
       <span class="help-block">{{afFieldMessage name="region"}}</span>
       {{/if}}

--- a/server/app.coffee
+++ b/server/app.coffee
@@ -62,7 +62,10 @@ _.extend ReactionCore,
     # global roles check
     else if Roles.userIsInRole Meteor.userId(), permissions, Roles.GLOBAL_GROUP
       return true
-    else return false
+    for shop in @getSellerShopId()
+      if Roles.userIsInRole Meteor.userId(), permissions, shop
+        return true
+    return false
 
   # owner access
   hasOwnerAccess: (client) ->
@@ -78,3 +81,7 @@ _.extend ReactionCore,
   hasDashboardAccess: (client) ->
     dashboardPermissions = ['owner','admin','dashboard']
     return @hasPermission dashboardPermissions
+ 
+  # return the logged in user's shop[s] if he owns any or if he is an admin -> used in multivendor
+  getSellerShopId: (client) ->
+    return Roles.getGroupsForUser Meteor.userId(), 'admin'

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -130,6 +130,7 @@ Meteor.publish 'ShopMembers', ->
 # products
 ###
 Meteor.publish 'Products', (shops) ->
+  check shops, Match.Optional(Array)
   shop = ReactionCore.getCurrentShop(@)
   if shop
     selector = {shopId: shop._id}


### PR DESCRIPTION
Hi Aaron,
According to what we have discussed on gitter I pushed a PR with the following changes:
1. Regarding the states dropdown there is a case that I didn't know how to handle, if you select a country with states and select a state then you select an other country without state the state code will remain in the region. Let me know what changes do you suggest.
2. Regarding the checking of the permissions I changes the getSellerShopId because the get Roles.groupsForUser doesn't support an array of roles as a parameter as you suggested in your version. I am currently checking for shop admins but let me know if we should change that to owner.
I also changes the hasPermission function to check for the seller permissions as well
[OPEN QUESTION]
Regarding these permissions I think we should think about adding a different kind of permission check used only in the server/methods/products.coffee where we could send an other parameter to the hasPermissions namely the shopId of the product that is about to get inserted/updated so we check if the user has permission in the given shop to change the products? What do you think?
