### PR TITLE
Allow database ids as valid slug (name) for tags.

### DIFF
--- a/common/routing.coffee
+++ b/common/routing.coffee
@@ -135,10 +135,7 @@ Router.map ->
     data: ->
       if @ready()
         id = @params._id
-        if id.match  /^[A-Za-z0-9]{17}$/
-          return tag: Tags.findOne(id)
-        else
-          return tag: Tags.findOne(slug: id.toLowerCase())
+        return tag : Tags.findOne(slug: id) || Tags.findOne(id)
 
   # product view / edit page
   @route 'product',


### PR DESCRIPTION
Before this change it was for example not possible to use a product id
as name (slug) for a tag, because the application interpreted the id as
a tag id, instead of a tag name.

A valid use case would be to display a link to a product's related products.
if using a product's id as tag name (slug) it is easy to build an URL to related products during template rendering e.g. product/tag/&lt;product_id> .

The old behaviour is still in service as a fallback.