### PR TITLE
Product metafields should be separate objects in Factory

### DIFF
--- a/server/factories.coffee
+++ b/server/factories.coffee
@@ -104,10 +104,12 @@ Factory.define 'product', ReactionCore.Collections.Products,
     metafields: [
       key: Fake.word()
       value: Fake.word()
-      scope: "detail",
+      scope: "detail"
+    ,
       key: "facebook"
       value: Fake.paragraph()
-      scope: "socialMessages",
+      scope: "socialMessages"
+    ,
       key: "twitter"
       value: Fake.sentence()
       scope: "socialMessages"


### PR DESCRIPTION
Product factory was formatted in a way that created only one meta-field object with multiple keys of the same name.