### PR TITLE
Eliminate coffeescript linter complaints.

### DIFF
--- a/common/collections/collections.coffee
+++ b/common/collections/collections.coffee
@@ -9,38 +9,52 @@
 # in code: ReactionCore.Collections.Cart.findOne().cartTotal()
 ###
 ReactionCore.Helpers.cartTransform =
+  
   cartCount : ->
     count = 0
-    ((count += items.quantity) for items in this.items) if this?.items
+    ((count += items.quantity) for items in @.items) if @?.items
     return count
+  
   cartShipping : ->
     shipping = 0
-    if this?.shipping?.shipmentMethod?.rate
-      shipping = this?.shipping?.shipmentMethod?.rate
-    else ((shipping += shippingMethod.rate) for shippingMethod in this.shipping.shipmentMethod) if this?.shipping?.shipmentMethod.length > 0
+    if @?.shipping?.shipmentMethod?.rate
+      shipping = @?.shipping?.shipmentMethod?.rate
+    else if @?.shipping?.shipmentMethod.length > 0
+      shipping += shippingMethod.rate \
+        for shippingMethod in @.shipping.shipmentMethod
     return shipping
+  
   cartSubTotal : ->
     subtotal = 0
-    ((subtotal += (items.quantity * items.variants.price)) for items in this.items) if this?.items
+    if @?.items
+      subtotal += (items.quantity * items.variants.price) for items in @.items
     subtotal = subtotal.toFixed(2)
     return subtotal
+  
   cartTaxes : ->
     ###
     # TODO: lookup cart taxes, and apply rules here
     ###
     return "0.00"
+  
   cartDiscounts : ->
     ###
     # TODO: lookup discounts, and apply rules here
     ###
     return "0.00"
+  
   cartTotal : ->
     subtotal = 0
-    ((subtotal += (items.quantity * items.variants.price)) for items in this.items) if this?.items
+    if @?.items
+      subtotal += (items.quantity * items.variants.price) for items in @.items
+    
     shipping = 0
-    if this?.shipping?.shipmentMethod?.rate
-      shipping = this?.shipping?.shipmentMethod?.rate
-    else ((shipping += shippingMethod.rate) for shippingMethod in this.shipping.shipmentMethod) if this?.shipping?.shipmentMethod.length > 0
+    if @?.shipping?.shipmentMethod?.rate
+      shipping = @?.shipping?.shipmentMethod?.rate
+    else if @?.shipping?.shipmentMethod.length > 0
+      shipping += shippingMethod.rate \
+      for shippingMethod in @.shipping.shipmentMethod
+      
     shipping = parseFloat shipping
     subtotal = (subtotal + shipping) unless isNaN(shipping)
     total = subtotal.toFixed(2)
@@ -48,47 +62,58 @@ ReactionCore.Helpers.cartTransform =
 
 ReactionCore.Collections.Cart = Cart = @Cart = new Mongo.Collection "Cart",
   transform: (cart) ->
-    newInstance = Object.create(ReactionCore.Helpers.cartTransform);
+    newInstance = Object.create(ReactionCore.Helpers.cartTransform)
 
-    return  _.extend newInstance, cart;
+    return  _.extend newInstance, cart
 
 
 ReactionCore.Collections.Cart.attachSchema ReactionCore.Schemas.Cart
 
 # Accounts
-ReactionCore.Collections.Accounts = Accounts = @Accounts = new Mongo.Collection "Accounts"
+ReactionCore.Collections.Accounts =
+  Accounts = @Accounts = new Mongo.Collection "Accounts"
+
 ReactionCore.Collections.Accounts.attachSchema ReactionCore.Schemas.Accounts
 
 # Orders
-ReactionCore.Collections.Orders = Orders = @Orders = new Mongo.Collection "Orders",
-  transform: (order) ->
-    order.itemCount = ->
-      count = 0
-      ((count += items.quantity) for items in order.items) if order?.items
-      return count
-    return order
+ReactionCore.Collections.Orders = Orders = @Orders =
+  new Mongo.Collection "Orders",
+    transform: (order) ->
+      order.itemCount = ->
+        count = 0
+        ((count += items.quantity) for items in order.items) if order?.items
+        return count
+      return order
 
-ReactionCore.Collections.Orders.attachSchema [ReactionCore.Schemas.Cart, ReactionCore.Schemas.Order, ReactionCore.Schemas.OrderItems]
+ReactionCore.Collections.Orders.attachSchema([
+  ReactionCore.Schemas.Cart,
+  ReactionCore.Schemas.Order,
+  ReactionCore.Schemas.OrderItems])
 
 # Packages
 ReactionCore.Collections.Packages = new Mongo.Collection "Packages"
-ReactionCore.Collections.Packages.attachSchema ReactionCore.Schemas.PackageConfig
+ReactionCore.Collections.Packages.attachSchema(
+  ReactionCore.Schemas.PackageConfig)
 
 # Products
-ReactionCore.Collections.Products = Products = @Products = new Mongo.Collection "Products"
-ReactionCore.Collections.Products.attachSchema ReactionCore.Schemas.Product
+ReactionCore.Collections.Products =
+  Products = @Products = new Mongo.Collection "Products"
+  
+ReactionCore.Collections.Products.attachSchema(
+  ReactionCore.Schemas.Product)
 
 # Shipping
 ReactionCore.Collections.Shipping = new Mongo.Collection "Shipping"
-ReactionCore.Collections.Shipping.attachSchema ReactionCore.Schemas.Shipping
+ReactionCore.Collections.Shipping.attachSchema(
+  ReactionCore.Schemas.Shipping)
 
 # Taxes
 ReactionCore.Collections.Taxes = new Mongo.Collection "Taxes"
-ReactionCore.Collections.Taxes.attachSchema ReactionCore.Schemas.Taxes
+ReactionCore.Collections.Taxes.attachSchema(ReactionCore.Schemas.Taxes)
 
 # Discounts
 ReactionCore.Collections.Discounts = new Mongo.Collection "Discounts"
-ReactionCore.Collections.Discounts.attachSchema ReactionCore.Schemas.Discounts
+ReactionCore.Collections.Discounts.attachSchema(ReactionCore.Schemas.Discounts)
 
 # Shops
 ReactionCore.Collections.Shops = Shops = @Shops = new Mongo.Collection "Shops",
@@ -98,7 +123,7 @@ ReactionCore.Collections.Shops = Shops = @Shops = new Mongo.Collection "Shops",
       member.user = Meteor.users.findOne member.userId
     return shop
 
-ReactionCore.Collections.Shops.attachSchema ReactionCore.Schemas.Shop
+ReactionCore.Collections.Shops.attachSchema(ReactionCore.Schemas.Shop)
 
 # Tags
 ReactionCore.Collections.Tags = Tags = @Tags = new Mongo.Collection "Tags"
@@ -106,4 +131,5 @@ ReactionCore.Collections.Tags.attachSchema ReactionCore.Schemas.Tag
 
 # Tags
 ReactionCore.Collections.Translations = new Mongo.Collection "Translations"
-ReactionCore.Collections.Translations.attachSchema ReactionCore.Schemas.Translation
+ReactionCore.Collections.Translations.attachSchema(
+  ReactionCore.Schemas.Translation)

--- a/common/schemas/products.coffee
+++ b/common/schemas/products.coffee
@@ -60,7 +60,8 @@ ReactionCore.Schemas.ProductVariant = new SimpleSchema
     optional: true
     custom: ->
       if Meteor.isClient
-        if @.siblingField("type").value is "inventory" and !@.value then return "required"
+        if @.siblingField("type").value is "inventory" and
+          !@.value then return "required"
   compareAtPrice:
     label: "MSRP"
     type: Number
@@ -78,21 +79,24 @@ ReactionCore.Schemas.ProductVariant = new SimpleSchema
     optional: true
     custom: ->
       if Meteor.isClient
-        unless @.siblingField("type").value is "inventory" or @.value or @.value == 0 then return "required"
+        unless @.siblingField("type").value is "inventory" or
+          @.value or @.value == 0 then return "required"
   inventoryManagement:
     type: Boolean
     label: "Inventory Tracking"
     optional: true
     custom: ->
       if Meteor.isClient
-        unless @.siblingField("type").value is "inventory" or @.value or @.value == false then return "required"
+        unless @.siblingField("type").value is "inventory" or
+          @.value or @.value == false then return "required"
   inventoryPolicy:
     type: Boolean
     label: "Deny when out of stock"
     optional: true
     custom: ->
       if Meteor.isClient
-        unless @.siblingField("type").value is "inventory" or @.value or @.value == false then return "required"
+        unless @.siblingField("type").value is "inventory" or
+          @.value or @.value == false then return "required"
   lowInventoryWarningThreshold:
     type: Number
     label: "Warn @"
@@ -105,7 +109,8 @@ ReactionCore.Schemas.ProductVariant = new SimpleSchema
     custom: ->
       if Meteor.isClient
         unless @.siblingField("type").value is "inventory"
-          if checkChildVariants(@.docId) is 0 and !@.value then return "required"
+          if checkChildVariants(@.docId) is 0 and
+            !@.value then return "required"
   price:
     label: "Price"
     type: Number
@@ -115,7 +120,8 @@ ReactionCore.Schemas.ProductVariant = new SimpleSchema
     custom: -> #required if no child variants (options) present
       if Meteor.isClient
         unless @.siblingField("type").value is "inventory"
-          if checkChildVariants(@.docId) is 0 and !@.value then return "required"
+          if checkChildVariants(@.docId) is 0 and
+            !@.value then return "required"
   sku:
     label: "SKU"
     type: String
@@ -134,7 +140,8 @@ ReactionCore.Schemas.ProductVariant = new SimpleSchema
     optional: true
     custom: -> #required unless type=inventory
       if Meteor.isClient
-        unless @.siblingField("type").value is "inventory" or @.value then return "required"
+        unless @.siblingField("type").value is "inventory" or
+          @.value then return "required"
   optionTitle:
     label: "Option"
     type: String
@@ -175,9 +182,6 @@ ReactionCore.Schemas.Product = new SimpleSchema
     type: String
   vendor:
     type: String
-    optional: true
-  positions:
-    type: [ReactionCore.Schemas.ProductPosition]
     optional: true
   metafields:
     type: [ReactionCore.Schemas.Metafield]
@@ -251,4 +255,3 @@ ReactionCore.Schemas.Product = new SimpleSchema
       else if @isUpsert
         return $setOnInsert: new Date
     optional: true
-

--- a/server/methods/products.coffee
+++ b/server/methods/products.coffee
@@ -1,6 +1,7 @@
 Meteor.methods
   ###
-  # the cloneVariant method copies variants, but will also create and clone child variants (options)
+  # the cloneVariant method copies variants, but will also create
+  # and clone child variants (options)
   # productId,variantId to clone
   # add parentId to create children
   # Note: parentId and variantId can be the same if creating a child variant.
@@ -15,7 +16,9 @@ Meteor.methods
 
     # clone variant
     product = Products.findOne(productId)
-    variant = (variant for variant in product.variants when variant._id is variantId)
+    variant = (
+      variant for variant in product.variants when variant._id is variantId)
+
     return false unless variant.length > 0
 
     clone = variant[0]
@@ -25,7 +28,8 @@ Meteor.methods
       ReactionCore.Events.debug "create child clone"
       clone.parentId = variantId
       delete clone.inventoryQuantity
-      Products.update({_id:productId}, {$push: {variants: clone}}, {validate: false})
+      Products.update(
+        {_id:productId}, {$push: {variants: clone}}, {validate: false})
       return clone._id
 
     #clean clone
@@ -34,16 +38,20 @@ Meteor.methods
     delete clone.createdAt
     delete clone.inventoryQuantity
     delete clone.title
-    Products.update({_id:productId}, {$push: {variants: clone}}, {validate: false})
+    Products.update(
+      {_id:productId}, {$push: {variants: clone}}, {validate: false})
 
     #make child clones
-    children = (variant for variant in product.variants when variant.parentId is variantId)
+    children = (variant for variant in product.variants \
+      when variant.parentId is variantId)
+    
     if children.length > 0
       ReactionCore.Events.debug "clone children"
       for childClone in children
         childClone._id = Random.id()
         childClone.parentId = clone._id
-        Products.update({_id:productId}, {$push: {variants: childClone}}, {validate: false})
+        Products.update(
+          {_id:productId}, {$push: {variants: childClone}}, {validate: false})
 
     return clone._id
 
@@ -64,8 +72,13 @@ Meteor.methods
       newVariant._id = newVariantId
       check(newVariant, ReactionCore.Schemas.ProductVariant)
     else
-      newVariant = { "_id": newVariantId, "title": "", "price": "0.00" }
-    Products.update({"_id": productId}, {$addToSet: {"variants": newVariant}}, {validate: false})
+      newVariant = { "_id": newVariantId, "title": "", "price": 0.00 }
+    
+    Products.update(
+      {"_id": productId},
+      {$addToSet: {"variants": newVariant}},
+      {validate: false})
+
     return newVariantId
 
   ###
@@ -90,8 +103,17 @@ Meteor.methods
       newVariant.type = "inventory"
       check(newVariant, ReactionCore.Schemas.ProductVariant)
     else
-      newVariant = { "_id": newVariantId, parentId: parentId, barcode: newBarcode, type: "inventory"}
-    Products.update({ "_id": productId }, { $addToSet: { "variants": newVariant }}, { validate: false })
+      newVariant =
+        "_id": newVariantId
+        parentId: parentId
+        barcode: newBarcode
+        type: "inventory"
+
+    Products.update(
+      { "_id": productId },
+      { $addToSet: { "variants": newVariant }},
+      { validate: false })
+      
     return newVariantId
   
   ###
@@ -128,11 +150,20 @@ Meteor.methods
       
       newVariantId = Random.id()
         
-      newVariants.push { "_id": newVariantId, parentId: parentId, barcode: newVariantBarcode, type: "inventory"}
+      newVariants.push
+        "_id": newVariantId
+        parentId: parentId
+        barcode: newVariantBarcode
+        type: "inventory"
+      
       newVariantIds.push newVariantId
     
     # Add array of inventory variants to Product's variants array.
-    Products.update({ "_id": productId }, { $addToSet: { "variants": { $each: newVariants }}}, { validate: false })
+    Products.update(
+      { "_id": productId },
+      { $addToSet: { "variants": { $each: newVariants }}},
+      { validate: false })
+      
     return newVariantIds
   ###
   # update individual variant with new values, merges into original
@@ -153,7 +184,11 @@ Meteor.methods
       for variants,value in product.variants
         if variants._id is variant._id
           newVariant = _.extend variants,variant
-      Products.update({"_id":product._id,"variants._id":variant._id}, {$set: {"variants.$": newVariant}}, {validate: false})
+      
+      Products.update(
+        {"_id":product._id,"variants._id":variant._id},
+        {$set: {"variants.$": newVariant}},
+        {validate: false})
 
 
   ###
@@ -179,21 +214,31 @@ Meteor.methods
     @unblock()
 
     #what will we be deleteing?
-    deleted = Products.find({$or: [{"variants.parentId": variantId}, {"variants._id": variantId}]}).fetch()
+    deleted = Products.find({$or: [
+      {"variants.parentId": variantId},
+      {"variants._id": variantId}]}).fetch()
+    
     #delete variants with this variant as parent
-    Products.update {"variants.parentId": variantId}, {$pull: 'variants': {'parentId': variantId}}
+    Products.update(
+      {"variants.parentId": variantId},
+      {$pull: 'variants': {'parentId': variantId}})
+      
     #delete this variant
-    Products.update {"variants._id": variantId}, {$pull: 'variants': {'_id': variantId}}
+    Products.update(
+      {"variants._id": variantId},
+      {$pull: 'variants': {'_id': variantId}})
+    
     # unlink media
     _.each deleted, (product) ->
       _.each product.variants, (variant) ->
         if variant.parentId is variantId or variant._id is variantId
-          ReactionCore.Collections.Media.update 'metadata.variantId': variant._id,
-            $unset:
+          ReactionCore.Collections.Media.update(
+            { 'metadata.variantId': variant._id},
+            { $unset: {
               'metadata.productId': ""
               'metadata.variantId': ""
-              'metadata.priority': ""
-          , multi: true
+              'metadata.priority': "" }},
+            { multi: true })
     return true
 
 
@@ -229,10 +274,16 @@ Meteor.methods
       newVariantId = Random.id()
       oldVariantId = product.variants[i]._id
       product.variants[i]._id = newVariantId
+      
       #clone images for each variant
-      ReactionCore.Collections.Media.find({'metadata.variantId': oldVariantId}).forEach (fileObj) ->
+      ReactionCore.Collections.Media.find(
+        {'metadata.variantId': oldVariantId}).forEach (fileObj) ->
         newFile = fileObj.copy()
-        newFile.update({$set: {'metadata.productId': product._id, 'metadata.variantId': newVariantId}})
+        newFile.update(
+          {$set: {
+            'metadata.productId': product._id,
+            'metadata.variantId': newVariantId }})
+            
       #update any child variants with the newly assigned ID
       unless product.variants[i].parentId
         while i < product.variants.length
@@ -327,7 +378,9 @@ Meteor.methods
     existingTag = Tags.findOne({"name": tagName})
 
     if existingTag
-      productCount = Products.find({"_id": productId, "hashtags": {$in:[existingTag._id]}}).count()
+      productCount = Products.find(
+        {"_id": productId, "hashtags": {$in:[existingTag._id]}}).count()
+      
       if productCount > 0
         throw new Meteor.Error 403, "Existing Tag, Update Denied"
       Products.update(productId, {$push: {"hashtags": existingTag._id}})
@@ -398,13 +451,19 @@ Meteor.methods
       throw new Meteor.Error 403, "Access Denied"
     @unblock()
 
-    unless Products.findOne({'_id' : productId,"positions.tag": positionData.tag})
-      Products.update {_id: productId},
-        {$addToSet: { positions: positionData },$set: {updatedAt: new Date() } },
-      , (error,results) ->
-        if error
-          ReactionCore.Events.warn error
-          throw new Meteor.Error 403, error
+    unless Products.findOne(
+      {'_id' : productId,"positions.tag": positionData.tag})
+      
+      Products.update(
+        { _id: productId },
+        {
+          $addToSet: { positions: positionData },
+          $set: {updatedAt: new Date() }
+        },
+        (error,results) ->
+          if error
+            ReactionCore.Events.warn error
+            throw new Meteor.Error 403, error )
     else
       #Collection2 doesn't support elemMatch, use core collection
       Products.update
@@ -431,9 +490,13 @@ Meteor.methods
     @unblock()
 
     if meta
-      Products.update({"_id": productId, "metafields": meta}, {$set: {"metafields.$": updatedMeta} })
+      Products.update(
+        { "_id": productId, "metafields": meta },
+        { $set: { "metafields.$": updatedMeta }})
     else
-      Products.update( "_id": productId, { "$addToSet": { "metafields": updatedMeta } })
+      Products.update(
+        { "_id": productId },
+        { "$addToSet": { "metafields": updatedMeta }})
 
   #
   # toggle isVisible status of product
@@ -446,11 +509,18 @@ Meteor.methods
 
     product = ReactionCore.Collections.Products.findOne(productId)
     #one variant required to publish product
-    if product?.variants[0].price and product?.variants[0].title and product?.title
+    if product?.variants[0].price and
+       product?.variants[0].title and
+       product?.title
+      
       # log this
-      ReactionCore.Events.info "toggle product visibility ", product._id, !product.isVisible
+      ReactionCore.Events.info(
+        "toggle product visibility ", product._id, !product.isVisible)
+      
       # toggle isVisible
-      result = Products.update product._id, {$set: {isVisible: !product.isVisible}}
+      result = Products.update(
+        product._id, {$set: {isVisible: !product.isVisible}})
+
       return Products.findOne(product._id).isVisible
     else
       # debug log this


### PR DESCRIPTION
Almost all changes are line-length related. Any non-obvious line-length breaks were run through a coffeescript compiler to ensure identical output. 

One change is duplicate keys in the product schema.