### PR TITLE
createVariant should use decimal number

### DIFF
--- a/server/methods/products.coffee
+++ b/server/methods/products.coffee
@@ -64,7 +64,7 @@ Meteor.methods
       newVariant._id = newVariantId
       check(newVariant, ReactionCore.Schemas.ProductVariant)
     else
-      newVariant = { "_id": newVariantId, "title": "", "price": "0.00" }
+      newVariant = { "_id": newVariantId, "title": "", "price": 0.00 }
     Products.update({"_id": productId}, {$addToSet: {"variants": newVariant}}, {validate: false})
     return newVariantId
 


### PR DESCRIPTION
`Meteor.method createVariant` should use a decimal number for price instead of a string per the schema.