### PR TITLE
Adjust clone product to be usable between multiple shops

### DIFF
--- a/server/methods/products.coffee
+++ b/server/methods/products.coffee
@@ -232,7 +232,7 @@ Meteor.methods
       #clone images for each variant
       ReactionCore.Collections.Media.find({'metadata.variantId': oldVariantId}).forEach (fileObj) ->
         newFile = fileObj.copy()
-        newFile.update({$set: {'metadata.productId': product._id, 'metadata.variantId': newVariantId}})
+        newFile.update({$set: {'metadata.productId': product._id, 'metadata.variantId': newVariantId, 'metadata.shopId': product.shopId}})
       #update any child variants with the newly assigned ID
       unless product.variants[i].parentId
         while i < product.variants.length


### PR DESCRIPTION
Hi Aaron,

I tested the clone product between the shops, actually I implemented a shop migration where the products had to be transferred to the newly created shop and everything seemed ok except the media files, they were unavailable in the new shop, I made some debugging and found the solution.

Hope this is helpfull,
Best regards,
Bogi