### PR TITLE
Typo.

### DIFF
--- a/private/data/Shops.json
+++ b/private/data/Shops.json
@@ -385,7 +385,7 @@
                 "enabled": true
             },
             {
-                "label": "Deutsche",
+                "label": "Deutsch",
                 "i18n": "de",
                 "enabled": true
             },


### PR DESCRIPTION
Typo. Must be Deutsch, not Deutsche