### PR TITLE
Missing error messages from product detail page

### DIFF
--- a/client/templates/products/productDetail/productDetail.coffee
+++ b/client/templates/products/productDetail/productDetail.coffee
@@ -131,6 +131,7 @@ Template.productDetail.events
 
   "click .toggle-product-isVisible-link": (event, template) ->
     errorMsg = ""
+    self = @
     unless @.title
         errorMsg += "Product title is required. "
         template.$(".title-edit-input").focus()
@@ -141,9 +142,12 @@ Template.productDetail.events
         errorMsg += "Variant " + (index + 1) + " price is required. "
 
     if errorMsg.length
-      Alerts.add errorMsg, "danger", placement: "productManagement", i18n_key: "productDetail.errorMsg"
+      Alerts.add errorMsg, "danger", placement: "productManagement", 'id': @._id, i18n_key: "productDetail.errorMsg"
     else
-      Meteor.call "publishProduct", @._id # toggle product visibility
+      Meteor.call "publishProduct", @._id, (error,result) -> # toggle product visibility
+        if error
+          errorMsg = error.message
+          Alerts.add errorMsg, "danger", placement: "productManagement", 'id': self._id, i18n_key: "productDetail.errorMsg"
     return
 
   "click .delete-product-link": (event, template) ->


### PR DESCRIPTION
Hi,
There were no error messages displayed because the id was missing from the error message placement when the products were published so I fixed this issue and I also checked if there are some errors from the server and display them, this is helpful when something goes wrong or when the server method is extended.

Best regards,
Bogi