### PR TITLE
Check for metafield property in current data context (not in parent data context).

### DIFF
--- a/client/templates/products/productDetail/attributes/attributes.html
+++ b/client/templates/products/productDetail/attributes/attributes.html
@@ -1,5 +1,5 @@
 <template name="productMetaField">
-{{#if ../metafields}}
+{{#if ./metafields}}
   <ul class="list-group metafield-list hidden-xs">
     {{#each ./metafields}}
       <li class="list-group-item metafield-list-item">


### PR DESCRIPTION
Otherwise the product details may not be rendered if it's called from a
custom template (not the one reaction-core is providing)
which has no metafield property attached to its parent data context.