### PR TITLE
Thai baht is always shown as THB and not TBD. The symbol is correct b…

### DIFF
--- a/private/data/Shops.json
+++ b/private/data/Shops.json
@@ -340,7 +340,7 @@
       "format": "%s%v",
       "symbol": "$"
     },
-    "TBD": {
+    "THB": {
       "format": "%s%v",
       "symbol": "฿"
     },


### PR DESCRIPTION
…ut the currencry indicator was off. Later in the file in the information about the countries it does show the correct THB for the currency.