### PR TITLE
Initialize results array in products/cloneVariant.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -41,6 +41,7 @@
      */
     "no-shadow": 2, // http://eslint.org/docs/rules/no-shadow
     "no-shadow-restricted-names": 2, // http://eslint.org/docs/rules/no-shadow-restricted-names
+    "no-const-assign": 2, // http://eslint.org/docs/rules/no-const-assign
     "no-unused-vars": [2, { // http://eslint.org/docs/rules/no-unused-vars
       "vars": "local",
       "args": "after-used"

--- a/server/methods/products.js
+++ b/server/methods/products.js
@@ -35,7 +35,7 @@ Meteor.methods({
     product = Products.findOne(productId);
     // create variant hierachy structure
     variant = (function () {
-      let results;
+      let results = [];
       for (let variant of product.variants) {
         if (variant._id === variantId) {
           results.push(variant);

--- a/server/methods/products.js
+++ b/server/methods/products.js
@@ -35,7 +35,7 @@ Meteor.methods({
     product = Products.findOne(productId);
     // create variant hierachy structure
     variant = (function () {
-      let results = [];
+      const results = [];
       for (let variant of product.variants) {
         if (variant._id === variantId) {
           results.push(variant);


### PR DESCRIPTION
Fixes `TypeError: Cannot call method 'push' of undefined` error that was getting thrown when calling `products/cloneVariant`

Error was pointing at https://github.com/reactioncommerce/reaction-core/blob/development/server/methods/products.js#L41 and is fixed by initializing results to an empty array.