### PR TITLE
Fixing autoValues for _id and shopId

### DIFF
--- a/common/common.js
+++ b/common/common.js
@@ -24,8 +24,8 @@ _.extend(ReactionCore, {
   shopIdAutoValue: function () {
     // we should always have a shopId
     if (ReactionCore.getShopId()) {
-      if (this.isSet && this.isFromTrustedCode) {
-        return ReactionCore.getShopId();
+      if (this.isSet && Meteor.isServer) {
+        return this.value;
       }
       if (Meteor.isClient && this.isInsert) {
         return ReactionCore.getShopId();
@@ -42,8 +42,8 @@ _.extend(ReactionCore, {
    * @return {String} returns randomId
    */
   schemaIdAutoValue: function () {
-    if (this.isSet && this.isFromTrustedCode) {
-      return Random.id();
+    if (this.isSet && Meteor.isServer) {
+      return this.value;
     }
     if (Meteor.isClient && this.isInsert) {
       return Random.id();

--- a/common/common.js
+++ b/common/common.js
@@ -26,10 +26,7 @@ _.extend(ReactionCore, {
     if (ReactionCore.getShopId()) {
       if (this.isSet && Meteor.isServer) {
         return this.value;
-      }
-      if (Meteor.isClient && this.isInsert) {
-        return ReactionCore.getShopId();
-      } else if (Meteor.isServer && (this.isInsert || this.isUpsert)) {
+      } else if (Meteor.isServer || Meteor.isClient && this.isInsert) {
         return ReactionCore.getShopId();
       }
       return this.unset();
@@ -44,11 +41,7 @@ _.extend(ReactionCore, {
   schemaIdAutoValue: function () {
     if (this.isSet && Meteor.isServer) {
       return this.value;
-    }
-    if (Meteor.isClient && this.isInsert) {
-      return Random.id();
-    } else if (Meteor.isServer && (this.isInsert || this.isUpsert || this
-        .isUpdate)) {
+    } else if (Meteor.isServer || Meteor.isClient && this.isInsert) {
       return Random.id();
     }
     return this.unset();


### PR DESCRIPTION
Some things seem to be wrong in the `shopIdAutoValue()` and `schemaIdAutoValue()` code. This PR includes:
* Don't use `isFromTrustedCode` from `aldeed:collection2`. Support seems to be incomplete and/or buggy. It doesn't exist in `aldeed:simple-schema`, so calling `SimpleSchema.clean()` doesn't work in any case. Also, it is equivalent to `Meteor.isServer`.
* When a value is already present it will no longer be overwritten.
* Always provide a `shopId` on the server (if it exists). Don't require `isInsert` or similar. We don't know what the code currently executing wants to accomplish, so when asked (from the server), we answer. Fixes #196.