### PR TITLE
When deleting a cart item, source of id should be the cartItem itself...

### DIFF
--- a/client/templates/cart/cartDrawer/cartDrawer.js
+++ b/client/templates/cart/cartDrawer/cartDrawer.js
@@ -62,11 +62,11 @@ Template.openCartDrawer.events({
     event.stopPropagation();
     event.preventDefault();
     let currentCartId = Cart.findOne()._id;
-    let currentVariant = this.variants;
+    let currentCartItem = this;
 
     return $(event.currentTarget).fadeOut(300, function () {
-      return Meteor.call("cart/removeFromCart", currentCartId,
-        currentVariant);
+      return Meteor.call("cart/removeFromCart",
+        currentCartId, currentCartItem);
     });
   }
 });

--- a/server/methods/cart.js
+++ b/server/methods/cart.js
@@ -243,12 +243,12 @@ Meteor.methods({
    * cart/removeFromCart
    * @summary removes a variant from the cart
    * @param {String} cartId - user cartId
-   * @param {String} variantData - variant object
+   * @param {String} cartItem - cart item object
    * @returns {String} returns Mongo update result
    */
-  "cart/removeFromCart": function (cartId, variantData) {
+  "cart/removeFromCart": function (cartId, cartItem) {
     check(cartId, String);
-    check(variantData, Object);
+    check(cartItem, Object);
     this.unblock();
 
     return Cart.update({
@@ -256,7 +256,7 @@ Meteor.methods({
     }, {
       $pull: {
         items: {
-          variants: variantData
+          variants: cartItem.variants
         }
       }
     });


### PR DESCRIPTION
…, not only the contained variantData.

This allows for deletion of just the cart item itself, instead of ALL INSTANCES
of cart items that have the same variantData. UseCase: Equal variants should not be
grouped together in cart, but instead be listed separately, even if the same item
exists multiple times in cart.

Note: Default behaviour is not changed. As before all items are grouped
if they are the same variant. But it allows for customizing the
cart/removeCart server function this way:

```
Meteor.default_server.method_handlers['cart/removeFromCart'] = function (cartId, cartItem) {
  check(cartId, String);
  check(cartItem, Object);
  this.unblock();

  return Cart.update({
    _id: cartId
  }, {
    $pull: {items: cartItem}
  });
};
```