### PR TITLE
Allow the main shop menu to be extended by reaction packages

### DIFF
--- a/client/templates/layout/header/header.html
+++ b/client/templates/layout/header/header.html
@@ -7,7 +7,7 @@
       <div class="cart-alert">{{> cartPanel}}</div>
       <div class="navbar-accounts">{{> accounts tpl="loginDropdown"}}</div>
       <div class="navbar-languages hidden-xs">{{> i18nChooser}}</div>
-      {{#each reactionTemplate workflow="coreLayout" container="navbar-shop"}}
+      {{#each reactionApps provides="menu"}}
         {{> Template.dynamic template=template}}
       {{/each}}
     </div>

--- a/client/templates/layout/header/header.html
+++ b/client/templates/layout/header/header.html
@@ -7,6 +7,9 @@
       <div class="cart-alert">{{> cartPanel}}</div>
       <div class="navbar-accounts">{{> accounts tpl="loginDropdown"}}</div>
       <div class="navbar-languages hidden-xs">{{> i18nChooser}}</div>
+      {{#each reactionTemplate workflow="coreLayout" container="navbar-shop"}}
+        {{> Template.dynamic template=template}}
+      {{/each}}
     </div>
     <div class="row navbar-primary-tags">
        <div class="navbar-tags">{{> headerTags}}</div>


### PR DESCRIPTION
The main shop menu should be extendable. This allows one to create packages that can integrate static or otherwise related website content into the shop.

This doesn't interfere with any CMS discussions already in progress.