### PR TITLE
ProductType on Cart Item

### DIFF
--- a/common/schemas/cart.js
+++ b/common/schemas/cart.js
@@ -24,6 +24,11 @@ ReactionCore.Schemas.CartItem = new SimpleSchema({
   },
   variants: {
     type: ReactionCore.Schemas.ProductVariant
+  },
+  type: {
+    label: "Product Type",
+    type: String,
+    optional: true
   }
 });
 

--- a/server/methods/cart.js
+++ b/server/methods/cart.js
@@ -228,7 +228,8 @@ Meteor.methods({
           shopId: product.shopId,
           productId: productId,
           quantity: quantity,
-          variants: variantData
+          variants: variantData,
+          type: product.type
         }
       }
     }, function (error) {


### PR DESCRIPTION
Within a cart and order, we would like to be able to check what type of Product the item belongs to without having to query the Product by the Product ID. It would be nice to have the product type field on the the Cart Items and the Order Items. This PR adds Type to ReactionCore.Schemas.CartItem it also extends the "cart/addToCart" method to pass along the Product Type.