### PR TITLE
New handle behavior

### DIFF
--- a/client/templates/products/productDetail/edit/edit.js
+++ b/client/templates/products/productDetail/edit/edit.js
@@ -20,7 +20,9 @@ Template.productDetailEdit.helpers({
 
 Template.productDetailEdit.events({
   "change input,textarea": function (event) {
-    Meteor.call("products/updateProductField", selectedProductId(), this.field,
+    const self = this;
+    const productId = selectedProductId();
+    Meteor.call("products/updateProductField", productId, this.field,
       $(event.currentTarget).val(),
       function (error) {
         if (error) {
@@ -28,6 +30,16 @@ Template.productDetailEdit.events({
             placement: "productManagement",
             i18nKey: "productDetail.errorMsg",
             id: this._id
+          });
+        }
+        //
+        if (self.field === 'title') {
+          Meteor.call("products/setHandle", productId, function (error, result) {
+            if (result) {
+              return Router.go("product", {
+                _id: result
+              });
+            }
           });
         }
         // animate updated field

--- a/common/common.js
+++ b/common/common.js
@@ -66,5 +66,57 @@ _.extend(ReactionCore, {
     }
     setCurrentProduct(productId);
     setCurrentVariant(variantId);
+  },
+  /**
+   * @summary Recursive method which trying to find a new handle, given the
+   * existing copies
+   * @param {String} handle - product handle
+   * @param {Object} product - current product cursor
+   * @return {String} handle - modified handle
+   */
+  createHandle: function (handle, product) {
+    // exception product._id needed for cases then double triggering happens
+    let handleCount = Products.find({
+      handle: handle,
+      _id: { $nin: [product._id]
+      }}).count();
+    // current product "copy" number
+    let handleNumberSuffix = 0;
+    // product handle prefix
+    let handleString = handle;
+    // copySuffix "-copy-number" suffix of product
+    let copySuffix = handleString.match(/-copy-\d+$/)
+      || handleString.match(/-copy$/);
+
+    // if product is a duplicate, we should take the copy number, and cut
+    // the handle
+    if (copySuffix) {
+      // we can have two cases here: copy-number and just -copy. If there is
+      // no numbers in copySuffix then we should put 1 in handleNumberSuffix
+      handleNumberSuffix = +String(copySuffix).match(/\d+$/) || 1;
+      // removing last numbers and last "-" if it presents
+      handleString = handle.replace(/\d+$/, '').replace(/-$/, '');
+    }
+
+    // if we have more than one product with the same handle, we should mark
+    // it as "copy" or increment our product handle if it contain numbers.
+    if (handleCount > 0) {
+      // if we have product with name like "product4", we should take care
+      // about its uniqueness
+      if (handleNumberSuffix > 0) {
+        handle = `${handleString}-${handleNumberSuffix + handleCount}`;
+      } else {
+        // first copy will be "...-copy", second: "...-copy-2"
+        handle = `${handleString}-copy${ handleCount > 1
+          ? '-' + handleCount : ''}`;
+      }
+    }
+
+    // we should check again if there are any new matches with DB
+    if (Products.find({ handle: handle }).count() !== 0) {
+      handle = ReactionCore.createHandle(handle, product);
+    }
+
+    return handle;
   }
 });

--- a/common/common.js
+++ b/common/common.js
@@ -71,14 +71,14 @@ _.extend(ReactionCore, {
    * @summary Recursive method which trying to find a new handle, given the
    * existing copies
    * @param {String} handle - product handle
-   * @param {Object} product - current product cursor
+   * @param {String} productId - current product _id
    * @return {String} handle - modified handle
    */
-  createHandle: function (handle, product) {
+  createHandle: function (handle, productId) {
     // exception product._id needed for cases then double triggering happens
     let handleCount = Products.find({
       handle: handle,
-      _id: { $nin: [product._id]
+      _id: { $nin: [productId]
       }}).count();
     // current product "copy" number
     let handleNumberSuffix = 0;
@@ -114,7 +114,7 @@ _.extend(ReactionCore, {
 
     // we should check again if there are any new matches with DB
     if (Products.find({ handle: handle }).count() !== 0) {
-      handle = ReactionCore.createHandle(handle, product);
+      handle = ReactionCore.createHandle(handle, productId);
     }
 
     return handle;

--- a/common/schemas/products.js
+++ b/common/schemas/products.js
@@ -330,7 +330,7 @@ ReactionCore.Schemas.Product = new SimpleSchema({
     optional: true,
     index: 1,
     autoValue: function () {
-      let slug = getSlug(this.siblingField("title").value || this.siblingField("_id").value || "");
+      let slug = this.siblingField("handle").value || getSlug(this.siblingField("title").value || this.siblingField("_id").value || "");
       if (this.isInsert) {
         return slug;
       } else if (this.isUpsert) {

--- a/common/schemas/products.js
+++ b/common/schemas/products.js
@@ -330,7 +330,7 @@ ReactionCore.Schemas.Product = new SimpleSchema({
     optional: true,
     index: 1,
     autoValue: function () {
-      let slug = this.siblingField("handle").value || getSlug(this.siblingField("title").value || this.siblingField("_id").value || "");
+      let slug = this.value ||  getSlug(this.siblingField("title").value || this.siblingField("_id").value || "");
       if (this.isInsert) {
         return slug;
       } else if (this.isUpsert) {

--- a/server/methods/products.js
+++ b/server/methods/products.js
@@ -440,9 +440,6 @@ Meteor.methods({
       delete product.publishedAt;
       delete product.handle;
       product.isVisible = false;
-      //if (product.title) {
-      //  product.title = product.title + handleCount;
-      //}
       if (product.title) {
         product.handle = ReactionCore.createHandle(
           getSlug(product.title),
@@ -748,6 +745,8 @@ Meteor.methods({
     let existingHandles = Products.find({
       handle: tag.slug
     }).fetch();
+    // this is needed to take care about product's handle which(product) was
+    // previously tagged.
     for (let currentProduct of existingHandles) {
       let currentProductHandle = ReactionCore.createHandle(
         getSlug(currentProduct.title),

--- a/server/methods/products.js
+++ b/server/methods/products.js
@@ -440,8 +440,14 @@ Meteor.methods({
       delete product.publishedAt;
       delete product.handle;
       product.isVisible = false;
+      //if (product.title) {
+      //  product.title = product.title + handleCount;
+      //}
       if (product.title) {
-        product.title = product.title + handleCount;
+        product.handle = ReactionCore.createHandle(
+          getSlug(product.title),
+          product._id
+        );
       }
       while (i < product.variants.length) {
         let newVariantId = Random.id();
@@ -697,7 +703,7 @@ Meteor.methods({
 
     let product = Products.findOne(productId);
     let handle = getSlug(product.title);
-    handle = ReactionCore.createHandle(handle, product);
+    handle = ReactionCore.createHandle(handle, product._id);
     Products.update(product._id, {
       $set: {
         handle: handle
@@ -729,7 +735,7 @@ Meteor.methods({
     // set handle
     if (product.handle === tag.slug) {
       let handle = getSlug(product.title);
-      handle = ReactionCore.createHandle(handle, product);
+      handle = ReactionCore.createHandle(handle, product._id);
       Products.update(product._id, {
         $set: {
           handle: handle
@@ -745,7 +751,7 @@ Meteor.methods({
     for (let currentProduct of existingHandles) {
       let currentProductHandle = ReactionCore.createHandle(
         getSlug(currentProduct.title),
-        currentProduct);
+        currentProduct._id);
       Products.update(currentProduct._id, {
         $set: {
           handle: currentProductHandle

--- a/server/methods/products.js
+++ b/server/methods/products.js
@@ -697,56 +697,7 @@ Meteor.methods({
 
     let product = Products.findOne(productId);
     let handle = getSlug(product.title);
-
-    /**
-     * @summary It trying to find a new handle, given the existing copies
-     * @param {Object} product - product object
-     * @param {String} handle - product handle string
-     */
-    /*let createHandle = (product, handle) => {
-      // exception product._id needed for cases then double triggering happens
-      let handleCount = Products.find({
-        handle: handle,
-        _id: { $nin: [product._id]
-       }}).count();
-      let handleNumberSuffix = 0;
-      let handleString = handle;
-      let copySuffix = handleString.match(/-copy-\d+$/)
-        || handleString.match(/-copy$/);
-
-      // if product is a duplicate, we should take the copy number, and cut
-      // the handle
-      if (copySuffix) {
-        // we can have two cases here: copy-number and just -copy. If there is
-        // no numbers in copySuffix then we should put 1 in handleNumberSuffix
-        handleNumberSuffix = +String(copySuffix).match(/\d+$/) || 1;
-        // removing last numbers and last "-" if it presents
-        handleString = handle.replace(/\d+$/, '').replace(/-$/, '');
-      }
-
-      // if we have more than one product with the same handle, we should mark
-      // it as "copy" or increment our product handle if it contain numbers.
-      if (handleCount > 0) {
-        // if we have product with name like "product4", we should take care
-        // about its uniqueness
-        if (handleNumberSuffix > 0) {
-          handle = `${handleString}-${handleNumberSuffix + handleCount}`;
-        } else {
-          // first copy will be "...-copy", second: "...-copy-2"
-          handle = `${handleString}-copy${ handleCount > 1
-            ? '-' + handleCount : ''}`;
-        }
-      }
-
-      // we should check again if there are any new matches with DB
-      if (Products.find({ handle: handle }).count() !== 0) {
-        handle = createHandle(product, handle);
-      }
-      return handle;
-    }*/
-
-    handle = ReactionCore.createHandle(handle, product); //createHandle(product, handle);
-
+    handle = ReactionCore.createHandle(handle, product);
     Products.update(product._id, {
       $set: {
         handle: handle
@@ -777,66 +728,8 @@ Meteor.methods({
     let tag = Tags.findOne(tagId);
     // set handle
     if (product.handle === tag.slug) {
-      /*Products.update(product._id, {
-        $unset: {
-          handle: ""
-        }
-      });*/
-
       let handle = getSlug(product.title);
-
-      /**
-       * @summary It trying to find a new handle, given the existing copies
-       * @param {String} handle - product handle
-       */
-      /*let createHandle = (handle) => {
-        // number of product handle copies
-        let handleCount = Products.find({
-          handle: handle,
-          _id: { $nin: [product._id]
-          }}).count();
-        // current product "copy" number
-        let handleNumberSuffix = 0;
-        // product handle prefix
-        let handleString = handle;
-        // copySuffix "-copy-number" suffix of product
-        let copySuffix = handleString.match(/-copy-\d+$/)
-          || handleString.match(/-copy$/);
-
-        // if product is a duplicate, we should take the copy number, and cut
-        // the handle
-        if (copySuffix) {
-          // we can have two cases here: copy-number and just -copy. If there is
-          // no numbers in copySuffix then we should put 1 in handleNumberSuffix
-          handleNumberSuffix = +String(copySuffix).match(/\d+$/) || 1;
-          // removing last numbers and last "-" if it presents
-          handleString = handle.replace(/\d+$/, '').replace(/-$/, '');
-        }
-
-        // if we have more than one product with the same handle, we should mark
-        // it as "copy" or increment our product handle if it contain numbers.
-        if (handleCount > 0) {
-          // if we have product with name like "product4", we should take care
-          // about its uniqueness
-          if (handleNumberSuffix > 0) {
-            handle = `${handleString}${handleNumberSuffix + handleCount}`;
-          } else {
-            // first copy will be "...-copy", second: "...-copy-2"
-            handle = `${handleString}-copy${ handleCount > 1
-              ? '-' + handleCount : ''}`;
-          }
-        }
-
-        // we should check again if there are any new matches with DB
-        if (Products.find({ handle: handle }).count() !== 0) {
-          handle = createHandle(handle);
-        }
-
-        return handle;
-      }*/
-
-      handle = ReactionCore.createHandle(handle, product); // createHandle(handle, product);
-
+      handle = ReactionCore.createHandle(handle, product);
       Products.update(product._id, {
         $set: {
           handle: handle
@@ -855,7 +748,6 @@ Meteor.methods({
         currentProduct);
       Products.update(currentProduct._id, {
         $set: {
-          //handle: ""
           handle: currentProductHandle
         }
       });


### PR DESCRIPTION
Hello, I found a strange behavior in "products/setHandleTag" method, which happens when you select tag on the product, another products handle which was selected before, became in _id instead of slugged string. I'm not really sure what is a purpose of this selection, but I've got an idea about expansion of this functionality.

Currently when we are cloning a product we get "productName" + 1 = "productName1" as a handle and product title. If we are cloning this clone, we will get: "product11" and so on.

What if we could leave the name as is - this is a clone anyway - and change only handle?
```
{
  title: 'product',
  handle: 'product'
}
```
cloning into:
```
{
  title: 'product',
  handle: 'product-copy'
}
```

another one clone will be:
```
{
  title: 'product',
  handle: 'product-copy-2'
}
```
and so on...

I think this is predictable behavior for cloning. Why is needed to use something like "-copy-"? Because, there can be situations with tech products, like phones, and it can be difficult to calculate number of clone (Nokia-1100, Philips-434, etc). So it can be whatever you like in -copy- place, but not number.

Then, I think It will be good to have handle update on title renaming.

If you are interesting in such changes, please take a look at the code. I'm not sure that I've done all right. There was a few unclear moments about which approach would be the best. I'm not sure that was right to put createHandle method to /common/common.js; then changes in schema can be wrong because I'm not familiar with simpleSchema yet, but on a first view everything works)

**Changes shortly:**
- fixed bug with selecting tag, which was already selected;
- changing product title will change his url;
- cloning, untagging and renaming adds -copy-number suffix to handle if needed.