### PR TITLE
bugfix: unable to remove variant with options

### DIFF
--- a/common/collections/hooks/hooks.js
+++ b/common/collections/hooks/hooks.js
@@ -180,7 +180,8 @@ ReactionCore.Collections.Products.before.update(function (userId, product,
         }
         return _results;
       })())[0];
-      if (removedVariant.parentId) {
+      if (typeof removedVariant === "object" &&
+        typeof removedVariant.parentId === "string") {
         updatedVariantId = removedVariant.parentId;
         updatedVariant = ((function () {
           let _i, _len, _ref12, _results;

--- a/common/common.js
+++ b/common/common.js
@@ -41,7 +41,8 @@ _.extend(ReactionCore, {
   schemaIdAutoValue: function () {
     if (this.isSet && Meteor.isServer) {
       return this.value;
-    } else if (Meteor.isServer || Meteor.isClient && this.isInsert) {
+    } else if ((Meteor.isServer && this.operator !== "$pull") ||
+      Meteor.isClient && this.isInsert) {
       return Random.id();
     }
     return this.unset();


### PR DESCRIPTION
Hello, there was a bug, then you can't remove variant if it has at least one option. SS `autoValue` does not check `$pull` operation.