### PR TITLE
Remove call to $(window) for server routes

### DIFF
--- a/common/router.js
+++ b/common/router.js
@@ -9,8 +9,10 @@ Router.configure({
   loadingTemplate: "loading",
 
   onRun: function () {
-    $(window).scrollTop(0);
-    ReactionCore.clearActionView();
+    if (Meteor.isClient) {
+      $(window).scrollTop(0);
+      ReactionCore.clearActionView();  
+    }
     this.next();
   },
 


### PR DESCRIPTION
Was having an issue setting up routes for webhooks and it boiled down to this `onRun` function trying to access the window object, even from the server side.